### PR TITLE
Update mobile keyboard to include decimal

### DIFF
--- a/src/components/ConverterForm.tsx
+++ b/src/components/ConverterForm.tsx
@@ -216,7 +216,7 @@ const ConverterForm = (): JSX.Element => {
                     <TextField
                         id="amountFrom"
                         label="Amount"
-                        inputMode="numeric"
+                        inputMode="decimal"
                         handleChange={ handleAmountChange }
                         handleKeyPress={ handleAmountEnter }
                         error={ errors.amountFrom }


### PR DESCRIPTION
When using mobile device, keyboard is only numeric, does not include decimal.

* update Amount inputmode to decimal, from numeric