### PR TITLE
chore: sync tooling — Prettier defaults, Husky, Yarn 4.14.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # production
 /dist
 
+# TypeScript
+tsconfig.tsbuildinfo
+
 # Netlify
 /netlify
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+yarn prettier --check . && yarn lint && yarn tsc -b && yarn test --run

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,1 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "tabWidth": 2
-}
+{}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,8 +1,3 @@
-approvedGitRepositories:
-  - "**"
-
-enableScripts: true
-
 nodeLinker: node-modules
 
 npmScopes:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,12 @@
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 nodeLinker: node-modules
 
 npmScopes:
   fortawesome:
-    npmRegistryServer: 'https://npm.fontawesome.com/'
     npmAlwaysAuth: true
-    npmAuthToken: ${FONTAWESOME_NPM_AUTH_TOKEN}
+    npmAuthToken: "${FONTAWESOME_NPM_AUTH_TOKEN}"
+    npmRegistryServer: "https://npm.fontawesome.com/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ PR #53 merged (2026-04-29). Branch `vite-migration` — all tasks done:
 
 ## Tooling sync — COMPLETE
 
-PR #54 merged. Branch `chore/sync-tooling`:
+PR #54 open: https://github.com/craigmcn/currency/pull/54 — merge when CI passes. Branch `chore/sync-tooling`:
 
 - [x] Reset `.prettierrc` to `{}` (all Prettier defaults); run format pass — switches from single→double quotes, etc.
 - [x] Add `format:check` script to `package.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ A single-page React 19 + TypeScript app (Vite 8) that converts amounts between c
 
 ## ESLint + Prettier
 
-Formatting is handled by Prettier (`.prettierrc`): single quotes, semicolons, 2-space indent. Run `yarn format` to apply. `.vscode/settings.json` sets Prettier as the default formatter with `formatOnSave`.
+Formatting is handled by Prettier (`.prettierrc` is `{}` — all defaults). Run `yarn format` to apply or `yarn format:check` to verify. `.vscode/settings.json` sets Prettier as the default formatter with `formatOnSave`.
 
 ESLint (`eslint.config.mjs`, ESLint 9 flat config, no `.eslintrc`) handles code quality only. Run `yarn lint` (read-only, fails on any error) or `yarn lint:fix`.
 
@@ -75,9 +75,9 @@ Rules in force:
 - **Prettier over `@stylistic`** — removed `@stylistic/eslint-plugin` in favour of Prettier + `eslint-config-prettier`. All formatting rules stripped from ESLint; `ecmaVersion: 5` and `sourceType: 'script'` bugs in the old config were fixed, which surfaced 12 real `comma-dangle` errors (auto-fixed).
 - **`.vscode/settings.json` committed** — `.gitignore` changed from `.vscode` → `.vscode/*` + `!.vscode/settings.json` so project editor settings are shared.
 
-## Modernization tasks (in-progress)
+## Modernization tasks — COMPLETE
 
-Branch `vite-migration` — 9 commits, not yet merged to main:
+PR #53 merged (2026-04-29). Branch `vite-migration` — all tasks done:
 
 - [x] Migrate Webpack + Babel → Vite 8; bump Node to 24
 - [x] Replace Sass with plain CSS; remove `sass` devDependency
@@ -90,12 +90,22 @@ Branch `vite-migration` — 9 commits, not yet merged to main:
 - [x] **Branch protection** — require PR, 1 approval, require `test` status check, dismiss stale reviews, block force push + deletion. Owner bypass is implicit (personal repo, `enforce_admins: false`).
 - [x] **Favicon** — no action needed. Favicons are served from the `craigmcnaughton` parent app at `www.craigmcn.com`; sub-path deploys inherit them correctly from the official domain.
 
+## Tooling sync — COMPLETE
+
+PR #54 merged. Branch `chore/sync-tooling`:
+
+- [x] Reset `.prettierrc` to `{}` (all Prettier defaults); run format pass — switches from single→double quotes, etc.
+- [x] Add `format:check` script to `package.json`
+- [x] Add Husky — `prepare: husky` in `package.json`; `.husky/pre-commit` runs `prettier --check . && yarn lint && yarn tsc -b && yarn test --run`
+- [x] Bump Yarn 4.9.1 → 4.14.1
+- [x] Add `src/vite-env.d.ts` (`/// <reference types="vite/client" />`) — fixes `import.meta.env` and CSS import type errors surfaced by the Yarn bump
+- [x] Import `FormatOptionLabelMeta` from `"react-select"` root (not deep internal path) — required under `moduleResolution: "bundler"`
+
 ## Follow-up items (non-blocking)
 
 - **`onKeyPress` → `onKeyDown`** in `src/fields/TextField.tsx` — `onKeyPress` is deprecated in React 17+ and removed from React 19 synthetic event types. Migrate to `onKeyDown`.
 - **`ConverterForm` integration test** — the same-currency validation logic (`restoreInvalid`, `setErrors` interactions) and the `useEffect` conversion math are currently untested. Worth adding a test for the duplicate-currency error path.
 - **`SelectField` interaction test** — no test for `handleChange` being called when the user selects an option (equivalent of the `TextField` `handleChange` test). Fiddly with react-select but the gap is real.
-- **CI Corepack** — `setup-node` does not enable Corepack automatically; must run `corepack enable` before the cached `setup-node` step so Yarn 4 is available. Already fixed in `test.yml`.
 
 ## Test suite notes
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,58 +1,58 @@
-import { defineConfig, globalIgnores } from 'eslint/config';
-import js from '@eslint/js';
-import react from 'eslint-plugin-react';
-import reactHooks from 'eslint-plugin-react-hooks';
-import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import prettierConfig from 'eslint-config-prettier';
+import { defineConfig, globalIgnores } from "eslint/config";
+import js from "@eslint/js";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import prettierConfig from "eslint-config-prettier";
 
 export default defineConfig([
-  globalIgnores(['**/node_modules']),
+  globalIgnores(["**/node_modules"]),
   js.configs.recommended,
-  typescriptEslint.configs['flat/eslint-recommended'],
-  ...typescriptEslint.configs['flat/recommended'],
+  typescriptEslint.configs["flat/eslint-recommended"],
+  ...typescriptEslint.configs["flat/recommended"],
   react.configs.flat.recommended,
-  reactHooks.configs['recommended-latest'],
+  reactHooks.configs["recommended-latest"],
   prettierConfig,
   {
     languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
+      ecmaVersion: "latest",
+      sourceType: "module",
     },
 
     settings: {
       react: {
-        version: 'detect',
+        version: "detect",
       },
     },
 
     rules: {
-      'no-console': 'warn',
-      'react/function-component-definition': [
+      "no-console": "warn",
+      "react/function-component-definition": [
         2,
-        { namedComponents: 'function-declaration' },
+        { namedComponents: "function-declaration" },
       ],
-      'react/jsx-no-bind': 'error',
-      'react/jsx-pascal-case': 'error',
-      'react/prop-types': 'off',
-      'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
-      '@typescript-eslint/member-ordering': 'error',
+      "react/jsx-no-bind": "error",
+      "react/jsx-pascal-case": "error",
+      "react/prop-types": "off",
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+      "@typescript-eslint/member-ordering": "error",
 
-      '@typescript-eslint/naming-convention': [
-        'error',
+      "@typescript-eslint/naming-convention": [
+        "error",
         {
-          selector: 'interface',
-          format: ['PascalCase'],
+          selector: "interface",
+          format: ["PascalCase"],
 
           custom: {
-            regex: '^I[A-Z]',
+            regex: "^I[A-Z]",
             match: true,
           },
         },
       ],
 
-      '@typescript-eslint/no-unused-vars': [
-        'error',
+      "@typescript-eslint/no-unused-vars": [
+        "error",
         {
           ignoreRestSiblings: true,
         },

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 
     <script>
       (() =>
-        !window.location.pathname.endsWith('/') &&
-        window.location.replace(window.location.href + '/'))();
+        !window.location.pathname.endsWith("/") &&
+        window.location.replace(window.location.href + "/"))();
     </script>
 
     <link

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "build:netlify": "vite build --outDir netlify && vite build --outDir netlify/currency",
     "dev": "vite",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "coverage": "vitest run --coverage",
     "preview": "vite preview",
     "start": "vite",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "prepare": "husky"
   },
   "keywords": [
     "currency",
@@ -52,6 +54,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "husky": "^9.1.7",
     "jsdom": "^29.1.0",
     "prettier": "^3.8.3",
     "typescript": "^5.8.3",
@@ -62,5 +65,5 @@
     "type": "git",
     "url": "https://github.com/craigmcn/currency.git"
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.14.1"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import React, { Fragment } from 'react';
-import Header from './components/Header';
-import Main from './components/Main';
-import Converter from './containers/Converter';
+import React, { Fragment } from "react";
+import Header from "./components/Header";
+import Main from "./components/Main";
+import Converter from "./containers/Converter";
 
 function App(): React.JSX.Element {
   return (

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React from "react";
 
 interface IProps {
   title: string;
-  type?: 'primary' | 'secondary';
+  type?: "primary" | "secondary";
   children?: React.ReactNode;
 }
 
 export function Card({ title, type, children }: IProps): React.JSX.Element {
-  const cardType = type ? ` card--${type}` : '';
+  const cardType = type ? ` card--${type}` : "";
 
   return (
     <div

--- a/src/components/ConverterForm.tsx
+++ b/src/components/ConverterForm.tsx
@@ -4,29 +4,28 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-} from 'react';
-import { SingleValue } from 'react-select';
-import { FormatOptionLabelMeta } from 'react-select/dist/declarations/src/Select';
-import Loader from './Loader';
-import { TextField } from '../fields/TextField';
-import { SelectField } from '../fields/SelectField';
-import ConverterContext from '../hooks/context';
-import { ICurrency, ICurrencyOption } from '../types';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationCircle } from '@fortawesome/duotone-light-svg-icons/faExclamationCircle';
-import _isEqual from 'lodash/isEqual';
-import { isBrowser } from 'react-device-detect';
-import SwitchButton from './SwitchButton';
-import '../styles/currencyOptions.css';
+} from "react";
+import { FormatOptionLabelMeta, SingleValue } from "react-select";
+import Loader from "./Loader";
+import { TextField } from "../fields/TextField";
+import { SelectField } from "../fields/SelectField";
+import ConverterContext from "../hooks/context";
+import { ICurrency, ICurrencyOption } from "../types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationCircle } from "@fortawesome/duotone-light-svg-icons/faExclamationCircle";
+import _isEqual from "lodash/isEqual";
+import { isBrowser } from "react-device-detect";
+import SwitchButton from "./SwitchButton";
+import "../styles/currencyOptions.css";
 
 const formatCurrencySelectOption = (
   { value, label, symbol, flag }: ICurrencyOption,
   { context, selectValue }: FormatOptionLabelMeta<ICurrencyOption>,
 ): React.JSX.Element => {
   const hl =
-    context === 'menu' && selectValue?.[0]?.value === value
-      ? ' option__label--secondary-hl'
-      : '';
+    context === "menu" && selectValue?.[0]?.value === value
+      ? " option__label--secondary-hl"
+      : "";
 
   return (
     <div className="option">
@@ -65,7 +64,7 @@ function ConverterForm(): React.JSX.Element {
   const setErrors = useCallback(
     (error: { [key: string]: string }): void => {
       dispatch({
-        type: 'SET_ERRORS',
+        type: "SET_ERRORS",
         payload: {
           ...errors,
           ...error,
@@ -79,13 +78,13 @@ function ConverterForm(): React.JSX.Element {
     (type: string): void => {
       let payload: number | ICurrencyOption | undefined;
       switch (type) {
-        case 'SET_AMOUNT_FROM':
+        case "SET_AMOUNT_FROM":
           payload = invalidAmountFrom;
           break;
-        case 'SET_CURRENCY_FROM':
+        case "SET_CURRENCY_FROM":
           payload = invalidCurrencyFrom;
           break;
-        case 'SET_CURRENCY_TO':
+        case "SET_CURRENCY_TO":
           payload = invalidCurrencyTo;
           break;
         default:
@@ -110,9 +109,9 @@ function ConverterForm(): React.JSX.Element {
         currencies?.find((c: ICurrency) => c.code === currencyTo?.value)
           ?.rate ?? 1;
 
-      dispatch({ type: 'SET_RATE', payload: rateTo / rateFrom });
+      dispatch({ type: "SET_RATE", payload: rateTo / rateFrom });
       dispatch({
-        type: 'SET_AMOUNT_TO',
+        type: "SET_AMOUNT_TO",
         payload: amountFrom && amountFrom * (rateTo / rateFrom),
       });
     }
@@ -124,14 +123,14 @@ function ConverterForm(): React.JSX.Element {
         (!invalidCurrencyTo && _isEqual(value, currencyTo)) ||
         (invalidCurrencyTo && _isEqual(value, invalidCurrencyTo))
       ) {
-        setErrors({ currencyFrom: 'Currencies must be different' });
-        dispatch({ type: 'SET_INVALID_CURRENCY_FROM', payload: value });
+        setErrors({ currencyFrom: "Currencies must be different" });
+        dispatch({ type: "SET_INVALID_CURRENCY_FROM", payload: value });
       } else {
-        setErrors({ currencyFrom: '', currencyTo: '' });
-        dispatch({ type: 'SET_CURRENCY_FROM', payload: value });
+        setErrors({ currencyFrom: "", currencyTo: "" });
+        dispatch({ type: "SET_CURRENCY_FROM", payload: value });
 
-        restoreInvalid('SET_CURRENCY_TO');
-        restoreInvalid('SET_AMOUNT_FROM');
+        restoreInvalid("SET_CURRENCY_TO");
+        restoreInvalid("SET_AMOUNT_FROM");
       }
     },
     [invalidCurrencyTo, currencyTo, setErrors, dispatch, restoreInvalid],
@@ -143,14 +142,14 @@ function ConverterForm(): React.JSX.Element {
         (!invalidCurrencyFrom && _isEqual(value, currencyFrom)) ||
         (invalidCurrencyFrom && _isEqual(value, invalidCurrencyFrom))
       ) {
-        setErrors({ currencyTo: 'Currencies must be different' });
-        dispatch({ type: 'SET_INVALID_CURRENCY_TO', payload: value });
+        setErrors({ currencyTo: "Currencies must be different" });
+        dispatch({ type: "SET_INVALID_CURRENCY_TO", payload: value });
       } else {
-        setErrors({ currencyFrom: '', currencyTo: '' });
-        dispatch({ type: 'SET_CURRENCY_TO', payload: value });
+        setErrors({ currencyFrom: "", currencyTo: "" });
+        dispatch({ type: "SET_CURRENCY_TO", payload: value });
 
-        restoreInvalid('SET_CURRENCY_FROM');
-        restoreInvalid('SET_AMOUNT_FROM');
+        restoreInvalid("SET_CURRENCY_FROM");
+        restoreInvalid("SET_AMOUNT_FROM");
       }
     },
     [invalidCurrencyFrom, currencyFrom, setErrors, dispatch, restoreInvalid],
@@ -160,15 +159,15 @@ function ConverterForm(): React.JSX.Element {
     (e: ChangeEvent<HTMLInputElement>): void => {
       const amount = Number(e.currentTarget.value);
       if (isNaN(amount) || amount === 0) {
-        setErrors({ amountFrom: 'Amount must be a number.' });
+        setErrors({ amountFrom: "Amount must be a number." });
       } else if (errors.currencyFrom || errors.currencyTo) {
-        dispatch({ type: 'SET_INVALID_AMOUNT_FROM', payload: amount });
+        dispatch({ type: "SET_INVALID_AMOUNT_FROM", payload: amount });
       } else {
-        setErrors({ amountFrom: '' });
-        dispatch({ type: 'SET_AMOUNT_FROM', payload: amount });
+        setErrors({ amountFrom: "" });
+        dispatch({ type: "SET_AMOUNT_FROM", payload: amount });
 
-        restoreInvalid('SET_CURRENCY_FROM');
-        restoreInvalid('SET_CURRENCY_TO');
+        restoreInvalid("SET_CURRENCY_FROM");
+        restoreInvalid("SET_CURRENCY_TO");
       }
     },
     [errors, setErrors, dispatch, restoreInvalid],
@@ -176,7 +175,7 @@ function ConverterForm(): React.JSX.Element {
 
   const handleAmountEnter = useCallback(
     (e: KeyboardEvent<HTMLInputElement>): void => {
-      if (e.key === 'Enter') {
+      if (e.key === "Enter") {
         (e.target as HTMLInputElement).blur();
       }
     },

--- a/src/components/ConverterResult.tsx
+++ b/src/components/ConverterResult.tsx
@@ -1,9 +1,9 @@
-import React, { Fragment, useContext } from 'react';
-import ConverterContext from '../hooks/context';
-import Error from './Error';
-import Card from './Card';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlayCircle } from '@fortawesome/duotone-light-svg-icons/faPlayCircle';
+import React, { Fragment, useContext } from "react";
+import ConverterContext from "../hooks/context";
+import Error from "./Error";
+import Card from "./Card";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlayCircle } from "@fortawesome/duotone-light-svg-icons/faPlayCircle";
 
 function ConverterResult(): React.JSX.Element {
   const {
@@ -23,20 +23,20 @@ function ConverterResult(): React.JSX.Element {
           <p>
             <strong>
               {currencyFrom?.symbol} {amountFrom} {currencyFrom?.value}
-            </strong>{' '}
+            </strong>{" "}
             equals
             <span
               className="text--primary text--large m-t-md m-b-xl"
-              style={{ display: 'block' }}
+              style={{ display: "block" }}
             >
               <strong>
-                {currencyTo?.symbol} {Number(amountTo).toFixed(3)}{' '}
+                {currencyTo?.symbol} {Number(amountTo).toFixed(3)}{" "}
                 {currencyTo?.value}
               </strong>
             </span>
           </p>
           <p className="text--muted">
-            Exchange rate: {currencyFrom?.value} 1 = {currencyTo?.value}{' '}
+            Exchange rate: {currencyFrom?.value} 1 = {currencyTo?.value}{" "}
             {rate.toPrecision(4)}
             <br />
             <small>{asOf && `As of ${asOf.toUTCString()}`}</small>

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationTriangle } from '@fortawesome/duotone-light-svg-icons/faExclamationTriangle';
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationTriangle } from "@fortawesome/duotone-light-svg-icons/faExclamationTriangle";
 
 interface IErrorProps {
   children: React.ReactNode;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import Logo from './Logo';
+import React from "react";
+import Logo from "./Logo";
 
 interface IProps {
   title: string;

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSyncAlt } from '@fortawesome/duotone-light-svg-icons/faSyncAlt';
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSyncAlt } from "@fortawesome/duotone-light-svg-icons/faSyncAlt";
 
 export function Loader(): React.JSX.Element {
   return (

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 function Logo(): React.JSX.Element {
   return (

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 interface IProps {
   fixed?: boolean;
@@ -6,7 +6,7 @@ interface IProps {
 }
 
 function Main({ fixed, children }: IProps): React.JSX.Element {
-  const mainFixed = fixed ? ' main--fixed' : '';
+  const mainFixed = fixed ? " main--fixed" : "";
 
   return <main className={`main${mainFixed}`}>{children}</main>;
 }

--- a/src/components/SwitchButton.tsx
+++ b/src/components/SwitchButton.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useContext } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSwap } from '@fortawesome/duotone-light-svg-icons';
-import ConverterContext from '../hooks/context';
-import '../styles/switchButton.css';
+import React, { useCallback, useContext } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSwap } from "@fortawesome/duotone-light-svg-icons";
+import ConverterContext from "../hooks/context";
+import "../styles/switchButton.css";
 
 function SwitchButton(): React.JSX.Element {
   const {
@@ -14,7 +14,7 @@ function SwitchButton(): React.JSX.Element {
 
   const handleCurrencySwitch = useCallback((): void => {
     if (currencyFrom && currencyTo) {
-      dispatch({ type: 'SWITCH_CURRENCIES' });
+      dispatch({ type: "SWITCH_CURRENCIES" });
     }
   }, [currencyFrom, currencyTo, dispatch]);
 

--- a/src/containers/Converter.tsx
+++ b/src/containers/Converter.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useReducer } from 'react';
-import ConverterContext from '../hooks/context';
-import converterReducer, { defaultState } from '../hooks/reducers';
-import { fetchUserData, fetchCurrencies } from '../utils';
-import { ICurrency } from '../types';
-import ConverterForm from '../components/ConverterForm';
-import ConverterResult from '../components/ConverterResult';
+import React, { useEffect, useReducer } from "react";
+import ConverterContext from "../hooks/context";
+import converterReducer, { defaultState } from "../hooks/reducers";
+import { fetchUserData, fetchCurrencies } from "../utils";
+import { ICurrency } from "../types";
+import ConverterForm from "../components/ConverterForm";
+import ConverterResult from "../components/ConverterResult";
 
 function Converter(): React.JSX.Element {
   const [state, dispatch] = useReducer(converterReducer, defaultState);
@@ -21,10 +21,10 @@ function Converter(): React.JSX.Element {
         (c: ICurrency) => c.code === user?.currency?.code,
       );
       const { code, name, symbol, flag } = userCurrency ?? {};
-      const value = code ?? '';
-      const label = name ?? '';
+      const value = code ?? "";
+      const label = name ?? "";
       dispatch({
-        type: 'SET_CURRENCY_FROM',
+        type: "SET_CURRENCY_FROM",
         payload: { value, label, symbol, flag },
       });
     }

--- a/src/fields/SelectField.test.tsx
+++ b/src/fields/SelectField.test.tsx
@@ -1,26 +1,26 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { SelectField } from './SelectField';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SelectField } from "./SelectField";
 
 const options = [
-  { value: 'EUR', label: 'Euro' },
-  { value: 'USD', label: 'US Dollar' },
+  { value: "EUR", label: "Euro" },
+  { value: "USD", label: "US Dollar" },
 ];
 
-describe('SelectField', () => {
-  it('renders a label', () => {
+describe("SelectField", () => {
+  it("renders a label", () => {
     render(<SelectField id="currency" label="Convert from currency" />);
-    expect(screen.getByText('Convert from currency')).toBeInTheDocument();
+    expect(screen.getByText("Convert from currency")).toBeInTheDocument();
   });
 
-  it('does not render an error message when no error prop is given', () => {
+  it("does not render an error message when no error prop is given", () => {
     render(<SelectField id="currency" label="Currency" options={options} />);
     expect(
-      document.querySelector('.form__control-error'),
+      document.querySelector(".form__control-error"),
     ).not.toBeInTheDocument();
   });
 
-  it('renders the error message when an error prop is given', () => {
+  it("renders the error message when an error prop is given", () => {
     render(
       <SelectField
         id="currency"
@@ -29,15 +29,17 @@ describe('SelectField', () => {
         error="Currencies must be different"
       />,
     );
-    expect(screen.getByText('Currencies must be different')).toBeInTheDocument();
+    expect(
+      screen.getByText("Currencies must be different"),
+    ).toBeInTheDocument();
   });
 
-  it('renders the select control', () => {
+  it("renders the select control", () => {
     render(<SelectField id="currency" label="Currency" options={options} />);
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
-  it('displays the selected option', () => {
+  it("displays the selected option", () => {
     render(
       <SelectField
         id="currency"
@@ -46,6 +48,6 @@ describe('SelectField', () => {
         selectedOption={options[0]}
       />,
     );
-    expect(screen.getByText('Euro')).toBeInTheDocument();
+    expect(screen.getByText("Euro")).toBeInTheDocument();
   });
 });

--- a/src/fields/SelectField.tsx
+++ b/src/fields/SelectField.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
-import Select, { OptionProps, SingleValue } from 'react-select';
-import { FormatOptionLabelMeta } from 'react-select/dist/declarations/src/Select';
+import React from "react";
+import Select, {
+  FormatOptionLabelMeta,
+  OptionProps,
+  SingleValue,
+} from "react-select";
 
 export interface ISelectOption {
   label: string;
@@ -26,21 +29,21 @@ type TProps = Partial<HTMLInputElement> & IProps;
 const customStyles = {
   control: (provided: Record<string, unknown>) => ({
     ...provided,
-    backgroundColor: 'var(--white)',
-    borderColor: 'var(--grey600)',
-    color: 'var(--black)',
+    backgroundColor: "var(--white)",
+    borderColor: "var(--grey600)",
+    color: "var(--black)",
   }),
   dropdownIndicator: (provided: Record<string, unknown>) => ({
     ...provided,
-    color: 'var(--grey600)',
+    color: "var(--grey600)",
   }),
   indicatorSeparator: (provided: Record<string, unknown>) => ({
     ...provided,
-    backgroundColor: 'var(--grey600)',
+    backgroundColor: "var(--grey600)",
   }),
   menu: (provided: Record<string, unknown>) => ({
     ...provided,
-    backgroundColor: 'var(--white)',
+    backgroundColor: "var(--white)",
   }),
   option: (
     provided: Record<string, unknown>,
@@ -48,22 +51,22 @@ const customStyles = {
   ) => ({
     ...provided,
     backgroundColor: state.isSelected
-      ? 'var(--primary)'
+      ? "var(--primary)"
       : state.isFocused
-        ? 'var(--primaryTransparent)'
-        : '',
-    color: state.isSelected ? 'var(--primaryContrast)' : 'var(--black)',
+        ? "var(--primaryTransparent)"
+        : "",
+    color: state.isSelected ? "var(--primaryContrast)" : "var(--black)",
   }),
   placeholder: (provided: Record<string, unknown>) => ({
     ...provided,
-    color: 'var(--grey600)',
+    color: "var(--grey600)",
   }),
   singleValue: (provided: Record<string, unknown>) => ({
     ...provided,
-    color: 'var(--black)',
-    overflow: 'visible',
-    paddingRight: '0.5em',
-    width: '100%',
+    color: "var(--black)",
+    overflow: "visible",
+    paddingRight: "0.5em",
+    width: "100%",
   }),
 };
 

--- a/src/fields/TextField.test.tsx
+++ b/src/fields/TextField.test.tsx
@@ -1,58 +1,56 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { TextField } from './TextField';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TextField } from "./TextField";
 
-describe('TextField', () => {
-  it('renders a label and input', () => {
+describe("TextField", () => {
+  it("renders a label and input", () => {
     render(<TextField id="amount" label="Amount" />);
-    expect(screen.getByLabelText('Amount')).toBeInTheDocument();
+    expect(screen.getByLabelText("Amount")).toBeInTheDocument();
   });
 
-  it('does not render an error message when no error prop is given', () => {
+  it("does not render an error message when no error prop is given", () => {
     render(<TextField id="amount" label="Amount" />);
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(
-      document.querySelector('.form__control-error'),
+      document.querySelector(".form__control-error"),
     ).not.toBeInTheDocument();
   });
 
-  it('renders the error message when an error prop is given', () => {
+  it("renders the error message when an error prop is given", () => {
     render(<TextField id="amount" label="Amount" error="Required" />);
-    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(screen.getByText("Required")).toBeInTheDocument();
   });
 
-  it('applies the error class to the input when an error is given', () => {
+  it("applies the error class to the input when an error is given", () => {
     render(<TextField id="amount" label="Amount" error="Required" />);
-    expect(screen.getByLabelText('Amount')).toHaveClass('form__control--hasError');
-  });
-
-  it('does not apply the error class when no error', () => {
-    render(<TextField id="amount" label="Amount" />);
-    expect(screen.getByLabelText('Amount')).not.toHaveClass(
-      'form__control--hasError',
+    expect(screen.getByLabelText("Amount")).toHaveClass(
+      "form__control--hasError",
     );
   });
 
-  it('calls handleChange when the input value changes', async () => {
+  it("does not apply the error class when no error", () => {
+    render(<TextField id="amount" label="Amount" />);
+    expect(screen.getByLabelText("Amount")).not.toHaveClass(
+      "form__control--hasError",
+    );
+  });
+
+  it("calls handleChange when the input value changes", async () => {
     const handleChange = vi.fn();
     render(
       <TextField id="amount" label="Amount" handleChange={handleChange} />,
     );
-    await userEvent.type(screen.getByLabelText('Amount'), '42');
+    await userEvent.type(screen.getByLabelText("Amount"), "42");
     expect(handleChange).toHaveBeenCalled();
   });
 
-  it('calls handleKeyPress when a key is pressed', async () => {
+  it("calls handleKeyPress when a key is pressed", async () => {
     const handleKeyPress = vi.fn();
     render(
-      <TextField
-        id="amount"
-        label="Amount"
-        handleKeyPress={handleKeyPress}
-      />,
+      <TextField id="amount" label="Amount" handleKeyPress={handleKeyPress} />,
     );
-    await userEvent.type(screen.getByLabelText('Amount'), '{Enter}');
+    await userEvent.type(screen.getByLabelText("Amount"), "{Enter}");
     expect(handleKeyPress).toHaveBeenCalled();
   });
 });

--- a/src/fields/TextField.tsx
+++ b/src/fields/TextField.tsx
@@ -3,7 +3,7 @@ import React, {
   DetailedHTMLProps,
   InputHTMLAttributes,
   KeyboardEvent,
-} from 'react';
+} from "react";
 
 interface IProps {
   label?: string;
@@ -37,7 +37,7 @@ export function TextField({
       <input
         id={id}
         name={id}
-        className={`form__control${error ? ' form__control--hasError' : ''}`}
+        className={`form__control${error ? " form__control--hasError" : ""}`}
         type="text"
         inputMode={inputMode}
         onChange={handleChange}

--- a/src/hooks/context.ts
+++ b/src/hooks/context.ts
@@ -1,6 +1,6 @@
-import { createContext } from 'react';
-import { IConversionState } from '../types';
-import { defaultState } from '../hooks/reducers';
+import { createContext } from "react";
+import { IConversionState } from "../types";
+import { defaultState } from "../hooks/reducers";
 
 interface IContextProps {
   state: IConversionState;

--- a/src/hooks/reducers.test.ts
+++ b/src/hooks/reducers.test.ts
@@ -1,227 +1,227 @@
-import converterReducer, { defaultState } from './reducers';
+import converterReducer, { defaultState } from "./reducers";
 
 const currency = (code: string) => ({ value: code, label: code });
 
-describe('converterReducer', () => {
-  describe('default', () => {
-    it('returns state unchanged for an unknown action', () => {
+describe("converterReducer", () => {
+  describe("default", () => {
+    it("returns state unchanged for an unknown action", () => {
       const result = converterReducer(defaultState, {
-        type: 'UNKNOWN',
+        type: "UNKNOWN",
         payload: null,
       });
       expect(result).toBe(defaultState);
     });
   });
 
-  describe('SET_USER', () => {
-    it('sets the user', () => {
-      const user = { currency: { code: 'CAD', name: 'Canadian Dollar' } };
+  describe("SET_USER", () => {
+    it("sets the user", () => {
+      const user = { currency: { code: "CAD", name: "Canadian Dollar" } };
       const result = converterReducer(defaultState, {
-        type: 'SET_USER',
+        type: "SET_USER",
         payload: user,
       });
       expect(result.user).toEqual(user);
     });
   });
 
-  describe('SET_TIMESTAMP', () => {
-    it('sets the timestamp', () => {
+  describe("SET_TIMESTAMP", () => {
+    it("sets the timestamp", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_TIMESTAMP',
+        type: "SET_TIMESTAMP",
         payload: 1234567890,
       });
       expect(result.timestamp).toBe(1234567890);
     });
   });
 
-  describe('SET_CURRENCIES', () => {
-    it('sets the currencies array', () => {
+  describe("SET_CURRENCIES", () => {
+    it("sets the currencies array", () => {
       const currencies = [
-        { name: 'Euro', code: 'EUR', symbol: '€', flag: '🇪🇺', rate: 1 },
+        { name: "Euro", code: "EUR", symbol: "€", flag: "🇪🇺", rate: 1 },
       ];
       const result = converterReducer(defaultState, {
-        type: 'SET_CURRENCIES',
+        type: "SET_CURRENCIES",
         payload: currencies,
       });
       expect(result.currencies).toEqual(currencies);
     });
   });
 
-  describe('SET_CURRENCY_LIST', () => {
-    it('sets the currency list', () => {
-      const list = [{ value: 'EUR', label: 'Euro' }];
+  describe("SET_CURRENCY_LIST", () => {
+    it("sets the currency list", () => {
+      const list = [{ value: "EUR", label: "Euro" }];
       const result = converterReducer(defaultState, {
-        type: 'SET_CURRENCY_LIST',
+        type: "SET_CURRENCY_LIST",
         payload: list,
       });
       expect(result.currencyList).toEqual(list);
     });
   });
 
-  describe('SET_CURRENCY_FROM', () => {
-    it('sets data.currencyFrom', () => {
+  describe("SET_CURRENCY_FROM", () => {
+    it("sets data.currencyFrom", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_CURRENCY_FROM',
-        payload: currency('EUR'),
+        type: "SET_CURRENCY_FROM",
+        payload: currency("EUR"),
       });
-      expect(result.data.currencyFrom).toEqual(currency('EUR'));
+      expect(result.data.currencyFrom).toEqual(currency("EUR"));
     });
 
-    it('clears invalid.currencyFrom', () => {
+    it("clears invalid.currencyFrom", () => {
       const state = {
         ...defaultState,
-        invalid: { ...defaultState.invalid, currencyFrom: currency('OLD') },
+        invalid: { ...defaultState.invalid, currencyFrom: currency("OLD") },
       };
       const result = converterReducer(state, {
-        type: 'SET_CURRENCY_FROM',
-        payload: currency('EUR'),
+        type: "SET_CURRENCY_FROM",
+        payload: currency("EUR"),
       });
       expect(result.invalid.currencyFrom).toBeUndefined();
     });
   });
 
-  describe('SET_INVALID_CURRENCY_FROM', () => {
-    it('sets invalid.currencyFrom', () => {
+  describe("SET_INVALID_CURRENCY_FROM", () => {
+    it("sets invalid.currencyFrom", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_INVALID_CURRENCY_FROM',
-        payload: currency('EUR'),
+        type: "SET_INVALID_CURRENCY_FROM",
+        payload: currency("EUR"),
       });
-      expect(result.invalid.currencyFrom).toEqual(currency('EUR'));
+      expect(result.invalid.currencyFrom).toEqual(currency("EUR"));
     });
   });
 
-  describe('SET_CURRENCY_TO', () => {
-    it('sets data.currencyTo', () => {
+  describe("SET_CURRENCY_TO", () => {
+    it("sets data.currencyTo", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_CURRENCY_TO',
-        payload: currency('USD'),
+        type: "SET_CURRENCY_TO",
+        payload: currency("USD"),
       });
-      expect(result.data.currencyTo).toEqual(currency('USD'));
+      expect(result.data.currencyTo).toEqual(currency("USD"));
     });
 
-    it('clears invalid.currencyTo', () => {
+    it("clears invalid.currencyTo", () => {
       const state = {
         ...defaultState,
-        invalid: { ...defaultState.invalid, currencyTo: currency('OLD') },
+        invalid: { ...defaultState.invalid, currencyTo: currency("OLD") },
       };
       const result = converterReducer(state, {
-        type: 'SET_CURRENCY_TO',
-        payload: currency('USD'),
+        type: "SET_CURRENCY_TO",
+        payload: currency("USD"),
       });
       expect(result.invalid.currencyTo).toBeUndefined();
     });
   });
 
-  describe('SET_INVALID_CURRENCY_TO', () => {
-    it('sets invalid.currencyTo', () => {
+  describe("SET_INVALID_CURRENCY_TO", () => {
+    it("sets invalid.currencyTo", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_INVALID_CURRENCY_TO',
-        payload: currency('USD'),
+        type: "SET_INVALID_CURRENCY_TO",
+        payload: currency("USD"),
       });
-      expect(result.invalid.currencyTo).toEqual(currency('USD'));
+      expect(result.invalid.currencyTo).toEqual(currency("USD"));
     });
   });
 
-  describe('SWITCH_CURRENCIES', () => {
-    it('swaps currencyFrom and currencyTo', () => {
+  describe("SWITCH_CURRENCIES", () => {
+    it("swaps currencyFrom and currencyTo", () => {
       const state = {
         ...defaultState,
         data: {
           ...defaultState.data,
-          currencyFrom: currency('EUR'),
-          currencyTo: currency('USD'),
+          currencyFrom: currency("EUR"),
+          currencyTo: currency("USD"),
         },
       };
       const result = converterReducer(state, {
-        type: 'SWITCH_CURRENCIES',
+        type: "SWITCH_CURRENCIES",
         payload: undefined,
       });
-      expect(result.data.currencyFrom).toEqual(currency('USD'));
-      expect(result.data.currencyTo).toEqual(currency('EUR'));
+      expect(result.data.currencyFrom).toEqual(currency("USD"));
+      expect(result.data.currencyTo).toEqual(currency("EUR"));
     });
   });
 
-  describe('SET_AMOUNT_FROM', () => {
-    it('sets data.amountFrom', () => {
+  describe("SET_AMOUNT_FROM", () => {
+    it("sets data.amountFrom", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_AMOUNT_FROM',
+        type: "SET_AMOUNT_FROM",
         payload: 42,
       });
       expect(result.data.amountFrom).toBe(42);
     });
 
-    it('clears invalid.amountFrom', () => {
+    it("clears invalid.amountFrom", () => {
       const state = {
         ...defaultState,
         invalid: { ...defaultState.invalid, amountFrom: 99 },
       };
       const result = converterReducer(state, {
-        type: 'SET_AMOUNT_FROM',
+        type: "SET_AMOUNT_FROM",
         payload: 42,
       });
       expect(result.invalid.amountFrom).toBeUndefined();
     });
   });
 
-  describe('SET_INVALID_AMOUNT_FROM', () => {
-    it('sets invalid.amountFrom', () => {
+  describe("SET_INVALID_AMOUNT_FROM", () => {
+    it("sets invalid.amountFrom", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_INVALID_AMOUNT_FROM',
+        type: "SET_INVALID_AMOUNT_FROM",
         payload: 99,
       });
       expect(result.invalid.amountFrom).toBe(99);
     });
   });
 
-  describe('SET_AMOUNT_TO', () => {
-    it('sets data.amountTo', () => {
+  describe("SET_AMOUNT_TO", () => {
+    it("sets data.amountTo", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_AMOUNT_TO',
+        type: "SET_AMOUNT_TO",
         payload: 55.5,
       });
       expect(result.data.amountTo).toBe(55.5);
     });
   });
 
-  describe('SET_RATE', () => {
-    it('sets data.rate', () => {
+  describe("SET_RATE", () => {
+    it("sets data.rate", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_RATE',
+        type: "SET_RATE",
         payload: 1.23,
       });
       expect(result.data.rate).toBe(1.23);
     });
   });
 
-  describe('SET_LOADING', () => {
-    it('sets loading to false', () => {
+  describe("SET_LOADING", () => {
+    it("sets loading to false", () => {
       const result = converterReducer(defaultState, {
-        type: 'SET_LOADING',
+        type: "SET_LOADING",
         payload: false,
       });
       expect(result.loading).toBe(false);
     });
 
-    it('sets loading to true', () => {
+    it("sets loading to true", () => {
       const state = { ...defaultState, loading: false };
       const result = converterReducer(state, {
-        type: 'SET_LOADING',
+        type: "SET_LOADING",
         payload: true,
       });
       expect(result.loading).toBe(true);
     });
   });
 
-  describe('SET_ERRORS', () => {
-    it('sets errors', () => {
+  describe("SET_ERRORS", () => {
+    it("sets errors", () => {
       const errors = {
-        _error: 'Something went wrong',
-        amountFrom: '',
-        currencyFrom: '',
-        currencyTo: '',
+        _error: "Something went wrong",
+        amountFrom: "",
+        currencyFrom: "",
+        currencyTo: "",
       };
       const result = converterReducer(defaultState, {
-        type: 'SET_ERRORS',
+        type: "SET_ERRORS",
         payload: errors,
       });
       expect(result.errors).toEqual(errors);

--- a/src/hooks/reducers.ts
+++ b/src/hooks/reducers.ts
@@ -1,13 +1,13 @@
-import { IConversionState, IConverterAction } from '../types';
+import { IConversionState, IConverterAction } from "../types";
 
 export const defaultState: IConversionState = {
   loading: true,
   timestamp: undefined,
   errors: {
-    _error: '',
-    amountFrom: '',
-    currencyFrom: '',
-    currencyTo: '',
+    _error: "",
+    amountFrom: "",
+    currencyFrom: "",
+    currencyTo: "",
   },
   data: {
     amountFrom: undefined,
@@ -31,31 +31,31 @@ const converterReducer = (
   action: IConverterAction,
 ): IConversionState => {
   switch (action.type) {
-    case 'SET_USER':
+    case "SET_USER":
       return {
         ...state,
         user: action.payload,
       };
 
-    case 'SET_TIMESTAMP':
+    case "SET_TIMESTAMP":
       return {
         ...state,
         timestamp: action.payload,
       };
 
-    case 'SET_CURRENCIES':
+    case "SET_CURRENCIES":
       return {
         ...state,
         currencies: action.payload,
       };
 
-    case 'SET_CURRENCY_LIST':
+    case "SET_CURRENCY_LIST":
       return {
         ...state,
         currencyList: action.payload,
       };
 
-    case 'SET_CURRENCY_FROM':
+    case "SET_CURRENCY_FROM":
       return {
         ...state,
         data: {
@@ -68,7 +68,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_INVALID_CURRENCY_FROM':
+    case "SET_INVALID_CURRENCY_FROM":
       return {
         ...state,
         invalid: {
@@ -77,7 +77,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_CURRENCY_TO':
+    case "SET_CURRENCY_TO":
       return {
         ...state,
         data: {
@@ -90,7 +90,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_INVALID_CURRENCY_TO':
+    case "SET_INVALID_CURRENCY_TO":
       return {
         ...state,
         invalid: {
@@ -99,7 +99,7 @@ const converterReducer = (
         },
       };
 
-    case 'SWITCH_CURRENCIES':
+    case "SWITCH_CURRENCIES":
       return {
         ...state,
         data: {
@@ -109,7 +109,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_AMOUNT_FROM':
+    case "SET_AMOUNT_FROM":
       return {
         ...state,
         data: {
@@ -122,7 +122,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_INVALID_AMOUNT_FROM':
+    case "SET_INVALID_AMOUNT_FROM":
       return {
         ...state,
         invalid: {
@@ -131,7 +131,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_AMOUNT_TO':
+    case "SET_AMOUNT_TO":
       return {
         ...state,
         data: {
@@ -140,7 +140,7 @@ const converterReducer = (
         },
       };
 
-    case 'SET_RATE':
+    case "SET_RATE":
       return {
         ...state,
         data: {
@@ -149,13 +149,13 @@ const converterReducer = (
         },
       };
 
-    case 'SET_LOADING':
+    case "SET_LOADING":
       return {
         ...state,
         loading: action.payload,
       };
 
-    case 'SET_ERRORS':
+    case "SET_ERRORS":
       return {
         ...state,
         errors: action.payload,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 
-const container = document.getElementById('root') as Element;
+const container = document.getElementById("root") as Element;
 const root = createRoot(container);
 root?.render(<App />);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { LookupResponse } from 'ipdata';
-import { ISelectOption } from './fields/SelectField';
+import { LookupResponse } from "ipdata";
+import { ISelectOption } from "./fields/SelectField";
 
 export interface IConverterAction {
   type: string;

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,18 +1,18 @@
-import { vi } from 'vitest';
-import { fetchCurrencies, fetchUserData } from './index';
+import { vi } from "vitest";
+import { fetchCurrencies, fetchUserData } from "./index";
 
-vi.mock('ipdata', () => ({
+vi.mock("ipdata", () => ({
   default: vi.fn().mockImplementation(function () {
     return {
       lookup: vi
         .fn()
-        .mockResolvedValue({ currency: { code: 'USD', name: 'US Dollar' } }),
+        .mockResolvedValue({ currency: { code: "USD", name: "US Dollar" } }),
     };
   }),
 }));
 
 const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
+vi.stubGlobal("fetch", mockFetch);
 
 const mockJsonResponse = (data: unknown) => ({
   json: () => Promise.resolve(data),
@@ -26,25 +26,25 @@ const mockRatesResponse = {
 // Only USD and GBP are in the currencyCountries map with their matching cca3 codes
 const mockCountriesResponse = [
   {
-    cca3: 'USA',
-    currencies: { USD: { name: 'US Dollar', symbol: '$' } },
-    flag: '🇺🇸',
+    cca3: "USA",
+    currencies: { USD: { name: "US Dollar", symbol: "$" } },
+    flag: "🇺🇸",
   },
   {
-    cca3: 'GBR',
-    currencies: { GBP: { name: 'Pound Sterling', symbol: '£' } },
-    flag: '🇬🇧',
+    cca3: "GBR",
+    currencies: { GBP: { name: "Pound Sterling", symbol: "£" } },
+    flag: "🇬🇧",
   },
 ];
 
-describe('fetchCurrencies', () => {
+describe("fetchCurrencies", () => {
   const dispatch = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('dispatches SET_TIMESTAMP, SET_CURRENCIES, SET_CURRENCY_LIST, SET_LOADING on success', async () => {
+  it("dispatches SET_TIMESTAMP, SET_CURRENCIES, SET_CURRENCY_LIST, SET_LOADING on success", async () => {
     mockFetch
       .mockResolvedValueOnce(mockJsonResponse(mockRatesResponse))
       .mockResolvedValueOnce(mockJsonResponse(mockCountriesResponse));
@@ -52,22 +52,22 @@ describe('fetchCurrencies', () => {
     await fetchCurrencies(dispatch);
 
     expect(dispatch).toHaveBeenCalledWith({
-      type: 'SET_TIMESTAMP',
+      type: "SET_TIMESTAMP",
       payload: mockRatesResponse.timestamp,
     });
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_CURRENCIES' }),
+      expect.objectContaining({ type: "SET_CURRENCIES" }),
     );
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_CURRENCY_LIST' }),
+      expect.objectContaining({ type: "SET_CURRENCY_LIST" }),
     );
     expect(dispatch).toHaveBeenCalledWith({
-      type: 'SET_LOADING',
+      type: "SET_LOADING",
       payload: false,
     });
   });
 
-  it('includes EUR as the base currency in SET_CURRENCIES', async () => {
+  it("includes EUR as the base currency in SET_CURRENCIES", async () => {
     mockFetch
       .mockResolvedValueOnce(mockJsonResponse(mockRatesResponse))
       .mockResolvedValueOnce(mockJsonResponse(mockCountriesResponse));
@@ -75,15 +75,15 @@ describe('fetchCurrencies', () => {
     await fetchCurrencies(dispatch);
 
     const setCurrenciesCall = dispatch.mock.calls.find(
-      ([action]) => action.type === 'SET_CURRENCIES',
+      ([action]) => action.type === "SET_CURRENCIES",
     );
     const currencies = setCurrenciesCall?.[0].payload;
-    expect(currencies.some((c: { code: string }) => c.code === 'EUR')).toBe(
+    expect(currencies.some((c: { code: string }) => c.code === "EUR")).toBe(
       true,
     );
   });
 
-  it('currencies are sorted alphabetically by name', async () => {
+  it("currencies are sorted alphabetically by name", async () => {
     mockFetch
       .mockResolvedValueOnce(mockJsonResponse(mockRatesResponse))
       .mockResolvedValueOnce(mockJsonResponse(mockCountriesResponse));
@@ -91,76 +91,75 @@ describe('fetchCurrencies', () => {
     await fetchCurrencies(dispatch);
 
     const setCurrenciesCall = dispatch.mock.calls.find(
-      ([action]) => action.type === 'SET_CURRENCIES',
+      ([action]) => action.type === "SET_CURRENCIES",
     );
     const currencies: { name: string }[] = setCurrenciesCall?.[0].payload;
     const names = currencies.map((c) => c.name);
     expect(names).toEqual([...names].sort());
   });
 
-  it('dispatches SET_ERRORS and SET_LOADING when the rates API returns an error', async () => {
+  it("dispatches SET_ERRORS and SET_LOADING when the rates API returns an error", async () => {
     mockFetch.mockResolvedValueOnce(
-      mockJsonResponse({ error: { message: 'API error' } }),
+      mockJsonResponse({ error: { message: "API error" } }),
     );
 
-    await expect(fetchCurrencies(dispatch)).rejects.toThrow('API error');
+    await expect(fetchCurrencies(dispatch)).rejects.toThrow("API error");
 
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_ERRORS' }),
+      expect.objectContaining({ type: "SET_ERRORS" }),
     );
     expect(dispatch).toHaveBeenCalledWith({
-      type: 'SET_LOADING',
+      type: "SET_LOADING",
       payload: false,
     });
   });
 
-  it('dispatches SET_ERRORS and SET_LOADING when fetch throws', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+  it("dispatches SET_ERRORS and SET_LOADING when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
 
-    await expect(fetchCurrencies(dispatch)).rejects.toThrow('Network failure');
+    await expect(fetchCurrencies(dispatch)).rejects.toThrow("Network failure");
 
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_ERRORS' }),
+      expect.objectContaining({ type: "SET_ERRORS" }),
     );
     expect(dispatch).toHaveBeenCalledWith({
-      type: 'SET_LOADING',
+      type: "SET_LOADING",
       payload: false,
     });
   });
-
 });
 
-describe('fetchUserData', () => {
+describe("fetchUserData", () => {
   const dispatch = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('dispatches SET_USER with the lookup result', async () => {
+  it("dispatches SET_USER with the lookup result", async () => {
     await fetchUserData(dispatch);
 
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_USER' }),
+      expect.objectContaining({ type: "SET_USER" }),
     );
   });
 
-  it('dispatches SET_USER even when response has a message', async () => {
-    const IPData = (await import('ipdata')).default as ReturnType<typeof vi.fn>;
+  it("dispatches SET_USER even when response has a message", async () => {
+    const IPData = (await import("ipdata")).default as ReturnType<typeof vi.fn>;
     IPData.mockImplementationOnce(function () {
       return {
         lookup: vi
           .fn()
-          .mockResolvedValue({ message: 'rate limited', currency: null }),
+          .mockResolvedValue({ message: "rate limited", currency: null }),
       };
     });
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     await fetchUserData(dispatch);
 
-    expect(warnSpy).toHaveBeenCalledWith('rate limited');
+    expect(warnSpy).toHaveBeenCalledWith("rate limited");
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'SET_USER' }),
+      expect.objectContaining({ type: "SET_USER" }),
     );
     warnSpy.mockRestore();
   });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,48 +1,48 @@
-import { Dispatch } from 'react';
-import IPData from 'ipdata';
+import { Dispatch } from "react";
+import IPData from "ipdata";
 import {
   IConverterAction,
   IIpData,
   ICurrency,
   IRestCountry,
   ICurrencyOption,
-} from '../types';
+} from "../types";
 
-const ipdataco = import.meta.env.VITE_IPDATA_CO ?? '';
+const ipdataco = import.meta.env.VITE_IPDATA_CO ?? "";
 
 const currencyCountries: { [key: string]: string } = {
-  CAD: 'CAN',
-  HKD: 'HKG',
-  ISK: 'ISL',
-  PHP: 'PHL',
-  DKK: 'DNK',
-  HUF: 'HUN',
-  CZK: 'CZE',
-  AUD: 'AUS',
-  RON: 'ROU',
-  SEK: 'SWE',
-  IDR: 'IDN',
-  INR: 'IND',
-  BRL: 'BRA',
-  RUB: 'RUS',
-  HRK: 'HRV',
-  JPY: 'JPN',
-  THB: 'THA',
-  CHF: 'CHE',
-  SGD: 'SGP',
-  PLN: 'POL',
-  BGN: 'BGR',
-  TRY: 'TUR',
-  CNY: 'CHN',
-  NOK: 'NOR',
-  NZD: 'NZL',
-  ZAR: 'ZAF',
-  USD: 'USA',
-  MXN: 'MEX',
-  ILS: 'ISR',
-  GBP: 'GBR',
-  KRW: 'KOR',
-  MYR: 'MYS',
+  CAD: "CAN",
+  HKD: "HKG",
+  ISK: "ISL",
+  PHP: "PHL",
+  DKK: "DNK",
+  HUF: "HUN",
+  CZK: "CZE",
+  AUD: "AUS",
+  RON: "ROU",
+  SEK: "SWE",
+  IDR: "IDN",
+  INR: "IND",
+  BRL: "BRA",
+  RUB: "RUS",
+  HRK: "HRV",
+  JPY: "JPN",
+  THB: "THA",
+  CHF: "CHE",
+  SGD: "SGP",
+  PLN: "POL",
+  BGN: "BGR",
+  TRY: "TUR",
+  CNY: "CHN",
+  NOK: "NOR",
+  NZD: "NZL",
+  ZAR: "ZAF",
+  USD: "USA",
+  MXN: "MEX",
+  ILS: "ISR",
+  GBP: "GBR",
+  KRW: "KOR",
+  MYR: "MYS",
 };
 
 const fetchUserData = async (
@@ -55,7 +55,7 @@ const fetchUserData = async (
     console.warn(data.message); // eslint-disable-line no-console
   }
 
-  dispatch({ type: 'SET_USER', payload: data });
+  dispatch({ type: "SET_USER", payload: data });
 };
 
 const fetchCurrencies = async (
@@ -66,7 +66,7 @@ const fetchCurrencies = async (
 
   try {
     const fetchRates = await fetch(
-      'https://api.craigmcn.com/v1/exchange-rates/latest',
+      "https://api.craigmcn.com/v1/exchange-rates/latest",
     );
     const fetchRatesJson = await fetchRates?.json();
 
@@ -74,11 +74,11 @@ const fetchCurrencies = async (
       throw new Error(fetchRatesJson?.error?.message);
     }
     currencies = fetchRatesJson?.rates;
-    dispatch({ type: 'SET_TIMESTAMP', payload: fetchRatesJson?.timestamp });
+    dispatch({ type: "SET_TIMESTAMP", payload: fetchRatesJson?.timestamp });
 
     if (currencies) {
       const fetchCountries = await fetch(
-        'https://restcountries.com/v3.1/all?fields=cca3,currencies,flag',
+        "https://restcountries.com/v3.1/all?fields=cca3,currencies,flag",
       );
       const fetchCountriesJson = await fetchCountries?.json();
 
@@ -99,10 +99,10 @@ const fetchCurrencies = async (
         [
           {
             // EUR is the base currency, not included in currencies data
-            name: 'European euro',
-            code: 'EUR',
-            symbol: '€',
-            flag: '🇪🇺',
+            name: "European euro",
+            code: "EUR",
+            symbol: "€",
+            flag: "🇪🇺",
             rate: 1,
           },
         ],
@@ -119,7 +119,7 @@ const fetchCurrencies = async (
       });
     }
 
-    dispatch({ type: 'SET_CURRENCIES', payload: countries });
+    dispatch({ type: "SET_CURRENCIES", payload: countries });
 
     if (countries?.length) {
       const countryOptions = countries.map(
@@ -130,25 +130,25 @@ const fetchCurrencies = async (
           flag: a.flag,
         }),
       );
-      dispatch({ type: 'SET_CURRENCY_LIST', payload: countryOptions });
+      dispatch({ type: "SET_CURRENCY_LIST", payload: countryOptions });
     } else {
-      const error = 'No country list available';
+      const error = "No country list available";
       dispatch({
-        type: 'SET_ERRORS',
+        type: "SET_ERRORS",
         payload: { _error: error },
       });
       throw new Error(error);
     }
 
-    dispatch({ type: 'SET_LOADING', payload: false });
+    dispatch({ type: "SET_LOADING", payload: false });
   } catch (e) {
     const _error =
       e instanceof Error || e instanceof TypeError ? e.message : (e as string);
     dispatch({
-      type: 'SET_ERRORS',
+      type: "SET_ERRORS",
       payload: { _error },
     });
-    dispatch({ type: 'SET_LOADING', payload: false });
+    dispatch({ type: "SET_LOADING", payload: false });
     throw new Error(_error);
   }
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,5 @@
-import '@testing-library/jest-dom/vitest';
-import { afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
 
 afterEach(cleanup);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  base: './',
+  base: "./",
   server: {
     port: 3030,
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,19 +1,19 @@
-import { mergeConfig } from 'vite';
-import { defineConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import { mergeConfig } from "vite";
+import { defineConfig } from "vitest/config";
+import viteConfig from "./vite.config";
 
 export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      environment: 'jsdom',
+      environment: "jsdom",
       globals: true,
-      setupFiles: './tests/setup.ts',
+      setupFiles: "./tests/setup.ts",
       coverage: {
-        provider: 'v8',
-        reporter: ['text', 'json', 'html'],
-        include: ['src/**/*.{ts,tsx}'],
-        exclude: ['src/index.tsx', 'src/types/**', '**/*.test.{ts,tsx}'],
+        provider: "v8",
+        reporter: ["text", "json", "html"],
+        include: ["src/**/*.{ts,tsx}"],
+        exclude: ["src/index.tsx", "src/types/**", "**/*.test.{ts,tsx}"],
       },
     },
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@adobe/css-tools@npm:^4.4.0":
@@ -1780,6 +1780,7 @@ __metadata:
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
+    husky: "npm:^9.1.7"
     ipdata: "npm:^2.2.4"
     jsdom: "npm:^29.1.0"
     lodash: "npm:^4.17.21"
@@ -2771,6 +2772,15 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Reset `.prettierrc` to `{}` (all Prettier defaults) and run a full format pass — primarily switches single → double quotes across the codebase
- Add `format:check` script and Husky pre-commit hook (`prettier --check . && yarn lint && yarn tsc -b && yarn test --run`)
- Bump Yarn 4.9.1 → 4.14.1 (`yarn set version 4.14.1`)
- Add `src/vite-env.d.ts` (`/// <reference types="vite/client" />`) — fixes `import.meta.env` and CSS import type errors surfaced by the Yarn bump under `moduleResolution: "bundler"`
- Import `FormatOptionLabelMeta` from `"react-select"` root instead of deep internal path (required under `moduleResolution: "bundler"`)
- Add `tsconfig.tsbuildinfo` to `.gitignore`

## Test plan

- [ ] CI passes (format:check, lint, build, tests)
- [ ] Pre-commit hook fires on a local commit and all steps pass
- [ ] `yarn tsc -b` exits clean with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)