### PR TITLE
fix: onKeyPress → onKeyDown; add ConverterForm and SelectField tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ PR #53 merged (2026-04-29). Branch `vite-migration` — all tasks done:
 
 ## Tooling sync — COMPLETE
 
-PR #54 open: https://github.com/craigmcn/currency/pull/54 — merge when CI passes. Branch `chore/sync-tooling`:
+PR #54 merged (2026-05-08). Branch `chore/sync-tooling`:
 
 - [x] Reset `.prettierrc` to `{}` (all Prettier defaults); run format pass — switches from single→double quotes, etc.
 - [x] Add `format:check` script to `package.json`
@@ -101,11 +101,13 @@ PR #54 open: https://github.com/craigmcn/currency/pull/54 — merge when CI pass
 - [x] Add `src/vite-env.d.ts` (`/// <reference types="vite/client" />`) — fixes `import.meta.env` and CSS import type errors surfaced by the Yarn bump
 - [x] Import `FormatOptionLabelMeta` from `"react-select"` root (not deep internal path) — required under `moduleResolution: "bundler"`
 
-## Follow-up items (non-blocking)
+## Follow-up items — COMPLETE
 
-- **`onKeyPress` → `onKeyDown`** in `src/fields/TextField.tsx` — `onKeyPress` is deprecated in React 17+ and removed from React 19 synthetic event types. Migrate to `onKeyDown`.
-- **`ConverterForm` integration test** — the same-currency validation logic (`restoreInvalid`, `setErrors` interactions) and the `useEffect` conversion math are currently untested. Worth adding a test for the duplicate-currency error path.
-- **`SelectField` interaction test** — no test for `handleChange` being called when the user selects an option (equivalent of the `TextField` `handleChange` test). Fiddly with react-select but the gap is real.
+PR #55 merged. Branch `fix/follow-ups`:
+
+- [x] `onKeyPress` → `onKeyDown` in `src/fields/TextField.tsx`, `TextField.test.tsx`, and `ConverterForm.tsx`
+- [x] `ConverterForm` integration test — duplicate-currency error path in `src/components/ConverterForm.test.tsx`; uses a real `useReducer` wrapper to exercise the full `handleCurrencyToChange` → `setErrors` → context update path
+- [x] `SelectField` `handleChange` interaction test — click to open menu, click option, assert callback; note react-select passes `(value, actionMeta)` so assertion uses `expect.objectContaining({ action: "select-option" })`
 
 ## Test suite notes
 

--- a/src/components/ConverterForm.test.tsx
+++ b/src/components/ConverterForm.test.tsx
@@ -1,0 +1,49 @@
+import React, { useReducer } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ConverterForm from "./ConverterForm";
+import ConverterContext from "../hooks/context";
+import converterReducer, { defaultState } from "../hooks/reducers";
+import { IConversionState } from "../types";
+
+const currencyList = [
+  { value: "EUR", label: "Euro" },
+  { value: "USD", label: "US Dollar" },
+];
+
+const readyState: IConversionState = {
+  ...defaultState,
+  loading: false,
+  currencyList,
+};
+
+function Wrapper({
+  initialState = readyState,
+}: {
+  initialState?: IConversionState;
+}) {
+  const [state, dispatch] = useReducer(converterReducer, initialState);
+  return (
+    <ConverterContext.Provider value={{ state, dispatch }}>
+      <ConverterForm />
+    </ConverterContext.Provider>
+  );
+}
+
+describe("ConverterForm", () => {
+  it("shows a duplicate-currency error when the same currency is chosen for both selects", async () => {
+    render(<Wrapper />);
+
+    const [fromCombobox, toCombobox] = screen.getAllByRole("combobox");
+
+    await userEvent.click(fromCombobox);
+    await userEvent.click(screen.getAllByRole("option")[0]); // Euro
+
+    await userEvent.click(toCombobox);
+    await userEvent.click(screen.getAllByRole("option")[0]); // Euro again
+
+    expect(
+      screen.getByText("Currencies must be different"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ConverterForm.tsx
+++ b/src/components/ConverterForm.tsx
@@ -224,7 +224,7 @@ function ConverterForm(): React.JSX.Element {
             label="Amount"
             inputMode="decimal"
             handleChange={handleAmountChange}
-            handleKeyPress={handleAmountEnter}
+            handleKeyDown={handleAmountEnter}
             error={errors.amountFrom}
           />
         </form>

--- a/src/fields/SelectField.test.tsx
+++ b/src/fields/SelectField.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SelectField } from "./SelectField";
 
 const options = [
@@ -49,5 +50,23 @@ describe("SelectField", () => {
       />,
     );
     expect(screen.getByText("Euro")).toBeInTheDocument();
+  });
+
+  it("calls handleChange when an option is selected", async () => {
+    const handleChange = vi.fn();
+    render(
+      <SelectField
+        id="currency"
+        label="Currency"
+        options={options}
+        handleChange={handleChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.click(screen.getAllByRole("option")[0]);
+    expect(handleChange).toHaveBeenCalledWith(
+      options[0],
+      expect.objectContaining({ action: "select-option" }),
+    );
   });
 });

--- a/src/fields/TextField.test.tsx
+++ b/src/fields/TextField.test.tsx
@@ -45,12 +45,12 @@ describe("TextField", () => {
     expect(handleChange).toHaveBeenCalled();
   });
 
-  it("calls handleKeyPress when a key is pressed", async () => {
-    const handleKeyPress = vi.fn();
+  it("calls handleKeyDown when a key is pressed", async () => {
+    const handleKeyDown = vi.fn();
     render(
-      <TextField id="amount" label="Amount" handleKeyPress={handleKeyPress} />,
+      <TextField id="amount" label="Amount" handleKeyDown={handleKeyDown} />,
     );
     await userEvent.type(screen.getByLabelText("Amount"), "{Enter}");
-    expect(handleKeyPress).toHaveBeenCalled();
+    expect(handleKeyDown).toHaveBeenCalled();
   });
 });

--- a/src/fields/TextField.tsx
+++ b/src/fields/TextField.tsx
@@ -9,7 +9,7 @@ interface IProps {
   label?: string;
   error?: string;
   handleChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  handleKeyPress?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  handleKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 type TProps = DetailedHTMLProps<
@@ -24,7 +24,7 @@ export function TextField({
   inputMode,
   error,
   handleChange,
-  handleKeyPress,
+  handleKeyDown,
 }: TProps): React.JSX.Element {
   return (
     <div className="form__group">
@@ -41,7 +41,7 @@ export function TextField({
         type="text"
         inputMode={inputMode}
         onChange={handleChange}
-        onKeyPress={handleKeyPress}
+        onKeyDown={handleKeyDown}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Replace deprecated `onKeyPress` with `onKeyDown` in `TextField` — `onKeyPress` was removed from React 19 synthetic event types; rename the prop (`handleKeyPress` → `handleKeyDown`) throughout `TextField.tsx`, `TextField.test.tsx`, and `ConverterForm.tsx`
- Add `ConverterForm` integration test for the duplicate-currency error path — renders with a real `useReducer` wrapper, selects the same currency for both fields, and asserts the "Currencies must be different" error appears
- Add `SelectField` `handleChange` interaction test — opens the dropdown, clicks an option, asserts the callback was invoked; react-select passes `(value, actionMeta)` to `onChange` so the assertion uses `expect.objectContaining({ action: "select-option" })`

Test count: 39 → 41.

## Test plan

- [ ] CI passes (format:check, lint, build, 41 tests)
- [ ] No TypeScript errors (`yarn tsc -b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)