### PR TITLE
fix: replace restcountries.com fetch with bundled static metadata

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -43,13 +43,6 @@ export interface ICurrency {
   rate?: number;
 }
 
-export interface ICurrencies {
-  [code: string]: {
-    name: string;
-    symbol: string;
-  };
-}
-
 export interface ICurrencyOption extends ISelectOption {
   symbol?: string;
   flag?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,12 +55,6 @@ export interface ICurrencyOption extends ISelectOption {
   flag?: string;
 }
 
-export interface IRestCountry {
-  cca3: string;
-  currencies: ICurrencies;
-  flag?: string;
-}
-
 export interface IIpData extends LookupResponse {
   message?: string;
 }

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -49,6 +49,7 @@ describe("fetchCurrencies", () => {
       type: "SET_LOADING",
       payload: false,
     });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("includes EUR as the base currency in SET_CURRENCIES", async () => {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -23,20 +23,6 @@ const mockRatesResponse = {
   timestamp: 1234567890,
 };
 
-// Only USD and GBP are in the currencyCountries map with their matching cca3 codes
-const mockCountriesResponse = [
-  {
-    cca3: "USA",
-    currencies: { USD: { name: "US Dollar", symbol: "$" } },
-    flag: "🇺🇸",
-  },
-  {
-    cca3: "GBR",
-    currencies: { GBP: { name: "Pound Sterling", symbol: "£" } },
-    flag: "🇬🇧",
-  },
-];
-
 describe("fetchCurrencies", () => {
   const dispatch = vi.fn();
 
@@ -45,9 +31,7 @@ describe("fetchCurrencies", () => {
   });
 
   it("dispatches SET_TIMESTAMP, SET_CURRENCIES, SET_CURRENCY_LIST, SET_LOADING on success", async () => {
-    mockFetch
-      .mockResolvedValueOnce(mockJsonResponse(mockRatesResponse))
-      .mockResolvedValueOnce(mockJsonResponse(mockCountriesResponse));
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(mockRatesResponse));
 
     await fetchCurrencies(dispatch);
 
@@ -68,9 +52,7 @@ describe("fetchCurrencies", () => {
   });
 
   it("includes EUR as the base currency in SET_CURRENCIES", async () => {
-    mockFetch
-      .mockResolvedValueOnce(mockJsonResponse(mockRatesResponse))
-      .mockResolvedValueOnce(mockJsonResponse(mockCountriesResponse));
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(mockRatesResponse));
 
     await fetchCurrencies(dispatch);
 
@@ -84,9 +66,7 @@ describe("fetchCurrencies", () => {
   });
 
   it("currencies are sorted alphabetically by name", async () => {
-    mockFetch
-      .mockResolvedValueOnce(mockJsonResponse(mockRatesResponse))
-      .mockResolvedValueOnce(mockJsonResponse(mockCountriesResponse));
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(mockRatesResponse));
 
     await fetchCurrencies(dispatch);
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -66,6 +66,39 @@ describe("fetchCurrencies", () => {
     );
   });
 
+  it("populates name, symbol, and flag from static metadata for API-returned codes", async () => {
+    mockFetch.mockResolvedValueOnce(mockJsonResponse(mockRatesResponse));
+
+    await fetchCurrencies(dispatch);
+
+    const setCurrenciesCall = dispatch.mock.calls.find(
+      ([action]) => action.type === "SET_CURRENCIES",
+    );
+    const currencies: {
+      code: string;
+      name: string;
+      symbol: string;
+      flag: string;
+      rate: number;
+    }[] = setCurrenciesCall?.[0].payload;
+
+    const usd = currencies.find((c) => c.code === "USD");
+    expect(usd).toMatchObject({
+      name: "United States dollar",
+      symbol: "$",
+      flag: "🇺🇸",
+      rate: 1.1,
+    });
+
+    const gbp = currencies.find((c) => c.code === "GBP");
+    expect(gbp).toMatchObject({
+      name: "Pound sterling",
+      symbol: "£",
+      flag: "🇬🇧",
+      rate: 0.85,
+    });
+  });
+
   it("currencies are sorted alphabetically by name", async () => {
     mockFetch.mockResolvedValueOnce(mockJsonResponse(mockRatesResponse));
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,8 +62,8 @@ const fetchUserData = async (
 const fetchCurrencies = async (
   dispatch: Dispatch<IConverterAction>,
 ): Promise<void> => {
-  let currencies: { [code: string]: number };
-  let countries: ICurrency[] = [];
+  let rates: { [code: string]: number };
+  let currencyList: ICurrency[] = [];
 
   try {
     const fetchRates = await fetch(
@@ -74,13 +74,13 @@ const fetchCurrencies = async (
     if (fetchRatesJson?.error) {
       throw new Error(fetchRatesJson?.error?.message);
     }
-    currencies = fetchRatesJson?.rates;
+    rates = fetchRatesJson?.rates;
     dispatch({ type: "SET_TIMESTAMP", payload: fetchRatesJson?.timestamp });
 
-    if (currencies) {
-      countries = Object.entries(currencyMetadata).reduce(
+    if (rates) {
+      currencyList = Object.entries(currencyMetadata).reduce(
         (a: ICurrency[], [code, meta]) => {
-          const rate = code === "EUR" ? 1 : currencies[code];
+          const rate = code === "EUR" ? 1 : rates[code];
           if (rate !== undefined) {
             a.push({ ...meta, code, rate });
           }
@@ -89,7 +89,7 @@ const fetchCurrencies = async (
         [],
       );
 
-      countries.sort((a: ICurrency, b: ICurrency) => {
+      currencyList.sort((a: ICurrency, b: ICurrency) => {
         if (a.name < b.name) {
           return -1;
         }
@@ -100,10 +100,10 @@ const fetchCurrencies = async (
       });
     }
 
-    dispatch({ type: "SET_CURRENCIES", payload: countries });
+    dispatch({ type: "SET_CURRENCIES", payload: currencyList });
 
-    if (countries?.length) {
-      const countryOptions = countries.map(
+    if (currencyList?.length) {
+      const currencyOptions = currencyList.map(
         (a: ICurrency): ICurrencyOption => ({
           value: a.code,
           label: a.name,
@@ -111,9 +111,9 @@ const fetchCurrencies = async (
           flag: a.flag,
         }),
       );
-      dispatch({ type: "SET_CURRENCY_LIST", payload: countryOptions });
+      dispatch({ type: "SET_CURRENCY_LIST", payload: currencyOptions });
     } else {
-      const error = "No country list available";
+      const error = "No currency list available";
       dispatch({
         type: "SET_ERRORS",
         payload: { _error: error },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,7 +23,6 @@ const currencyMetadata: {
   EUR: { name: "European euro", symbol: "€", flag: "🇪🇺" },
   GBP: { name: "Pound sterling", symbol: "£", flag: "🇬🇧" },
   HKD: { name: "Hong Kong dollar", symbol: "HK$", flag: "🇭🇰" },
-  HRK: { name: "Croatian kuna", symbol: "kn", flag: "🇭🇷" },
   HUF: { name: "Hungarian forint", symbol: "Ft", flag: "🇭🇺" },
   IDR: { name: "Indonesian rupiah", symbol: "Rp", flag: "🇮🇩" },
   ILS: { name: "Israeli new shekel", symbol: "₪", flag: "🇮🇱" },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,45 +4,47 @@ import {
   IConverterAction,
   IIpData,
   ICurrency,
-  IRestCountry,
   ICurrencyOption,
 } from "../types";
 
 const ipdataco = import.meta.env.VITE_IPDATA_CO ?? "";
 
-const currencyCountries: { [key: string]: string } = {
-  CAD: "CAN",
-  HKD: "HKG",
-  ISK: "ISL",
-  PHP: "PHL",
-  DKK: "DNK",
-  HUF: "HUN",
-  CZK: "CZE",
-  AUD: "AUS",
-  RON: "ROU",
-  SEK: "SWE",
-  IDR: "IDN",
-  INR: "IND",
-  BRL: "BRA",
-  RUB: "RUS",
-  HRK: "HRV",
-  JPY: "JPN",
-  THB: "THA",
-  CHF: "CHE",
-  SGD: "SGP",
-  PLN: "POL",
-  BGN: "BGR",
-  TRY: "TUR",
-  CNY: "CHN",
-  NOK: "NOR",
-  NZD: "NZL",
-  ZAR: "ZAF",
-  USD: "USA",
-  MXN: "MEX",
-  ILS: "ISR",
-  GBP: "GBR",
-  KRW: "KOR",
-  MYR: "MYS",
+const currencyMetadata: {
+  [code: string]: { name: string; symbol: string; flag: string };
+} = {
+  AUD: { name: "Australian dollar", symbol: "A$", flag: "🇦🇺" },
+  BGN: { name: "Bulgarian lev", symbol: "лв", flag: "🇧🇬" },
+  BRL: { name: "Brazilian real", symbol: "R$", flag: "🇧🇷" },
+  CAD: { name: "Canadian dollar", symbol: "CA$", flag: "🇨🇦" },
+  CHF: { name: "Swiss franc", symbol: "Fr", flag: "🇨🇭" },
+  CNY: { name: "Chinese yuan", symbol: "¥", flag: "🇨🇳" },
+  CZK: { name: "Czech koruna", symbol: "Kč", flag: "🇨🇿" },
+  DKK: { name: "Danish krone", symbol: "kr", flag: "🇩🇰" },
+  EUR: { name: "European euro", symbol: "€", flag: "🇪🇺" },
+  GBP: { name: "Pound sterling", symbol: "£", flag: "🇬🇧" },
+  HKD: { name: "Hong Kong dollar", symbol: "HK$", flag: "🇭🇰" },
+  HRK: { name: "Croatian kuna", symbol: "kn", flag: "🇭🇷" },
+  HUF: { name: "Hungarian forint", symbol: "Ft", flag: "🇭🇺" },
+  IDR: { name: "Indonesian rupiah", symbol: "Rp", flag: "🇮🇩" },
+  ILS: { name: "Israeli new shekel", symbol: "₪", flag: "🇮🇱" },
+  INR: { name: "Indian rupee", symbol: "₹", flag: "🇮🇳" },
+  ISK: { name: "Icelandic króna", symbol: "kr", flag: "🇮🇸" },
+  JPY: { name: "Japanese yen", symbol: "¥", flag: "🇯🇵" },
+  KRW: { name: "South Korean won", symbol: "₩", flag: "🇰🇷" },
+  MXN: { name: "Mexican peso", symbol: "$", flag: "🇲🇽" },
+  MYR: { name: "Malaysian ringgit", symbol: "RM", flag: "🇲🇾" },
+  NOK: { name: "Norwegian krone", symbol: "kr", flag: "🇳🇴" },
+  NZD: { name: "New Zealand dollar", symbol: "NZ$", flag: "🇳🇿" },
+  PHP: { name: "Philippine peso", symbol: "₱", flag: "🇵🇭" },
+  PLN: { name: "Polish złoty", symbol: "zł", flag: "🇵🇱" },
+  RON: { name: "Romanian leu", symbol: "lei", flag: "🇷🇴" },
+  RUB: { name: "Russian ruble", symbol: "₽", flag: "🇷🇺" },
+  SEK: { name: "Swedish krona", symbol: "kr", flag: "🇸🇪" },
+  SGD: { name: "Singapore dollar", symbol: "S$", flag: "🇸🇬" },
+  THB: { name: "Thai baht", symbol: "฿", flag: "🇹🇭" },
+  TRY: { name: "Turkish lira", symbol: "₺", flag: "🇹🇷" },
+  USD: { name: "United States dollar", symbol: "$", flag: "🇺🇸" },
+  ZAR: { name: "South African rand", symbol: "R", flag: "🇿🇦" },
 };
 
 const fetchUserData = async (
@@ -77,35 +79,15 @@ const fetchCurrencies = async (
     dispatch({ type: "SET_TIMESTAMP", payload: fetchRatesJson?.timestamp });
 
     if (currencies) {
-      const fetchCountries = await fetch(
-        "https://restcountries.com/v3.1/all?fields=cca3,currencies,flag",
-      );
-      const fetchCountriesJson = await fetchCountries?.json();
-
-      countries = fetchCountriesJson?.reduce(
-        (a: ICurrency[], c: IRestCountry) => {
-          const code = Object.keys(c?.currencies)[0];
-          if (c.cca3 === currencyCountries[code]) {
-            a.push({
-              name: c.currencies[code].name,
-              code: code,
-              symbol: c.currencies[code].symbol,
-              flag: c.flag,
-              rate: currencies[code],
-            });
+      countries = Object.entries(currencyMetadata).reduce(
+        (a: ICurrency[], [code, meta]) => {
+          const rate = code === "EUR" ? 1 : currencies[code];
+          if (rate !== undefined) {
+            a.push({ ...meta, code, rate });
           }
           return a;
         },
-        [
-          {
-            // EUR is the base currency, not included in currencies data
-            name: "European euro",
-            code: "EUR",
-            symbol: "€",
-            flag: "🇪🇺",
-            rate: 1,
-          },
-        ],
+        [],
       );
 
       countries.sort((a: ICurrency, b: ICurrency) => {


### PR DESCRIPTION
## Summary

- `restcountries.com` blocks CORS requests from `www.craigmcn.com`, causing currency metadata to fail silently on load
- Replaced the runtime fetch with a static `currencyMetadata` table (name, symbol, flag) bundled directly in `src/utils/index.ts`
- Removed `IRestCountry` type and the `currencyCountries` cca3 map, which were only needed to cross-reference the now-removed API response
- Updated tests: the second mocked `fetch` call (for restcountries.com) is no longer needed and was removed from the three success-path tests

## Test plan

- [ ] `yarn test --run` — all 41 tests pass
- [ ] `yarn tsc -b` — no type errors
- [ ] `yarn lint` — clean
- [ ] Load production site at www.craigmcn.com — currency selects populate and conversion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)