### PR TITLE
refactor: migrate exchange rates to Netlify function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tsconfig.tsbuildinfo
 
 # Netlify
 /netlify
+deno.lock
 
 # misc
 .DS_Store
@@ -47,3 +48,6 @@ yarn-error.log*
 # VS Code
 .vscode/*
 !.vscode/settings.json
+
+# Local Netlify folder
+.netlify

--- a/functions/exchange-rates.js
+++ b/functions/exchange-rates.js
@@ -1,12 +1,28 @@
 export default async () => {
-  const url = `https://api.exchangeratesapi.io/v1/latest?access_key=${process.env.EXCHANGE_RATES_API_KEY}`;
-  const res = await fetch(url);
-  const data = await res.json();
+  if (!process.env.EXCHANGE_RATES_API_KEY) {
+    return new Response(
+      JSON.stringify({
+        error: { message: "Exchange rates API key is not configured" },
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
 
-  return new Response(JSON.stringify(data), {
-    status: res.status,
-    headers: { "Content-Type": "application/json" },
-  });
+  try {
+    const url = `https://api.exchangeratesapi.io/v1/latest?access_key=${process.env.EXCHANGE_RATES_API_KEY}`;
+    const res = await fetch(url);
+    const data = await res.json();
+
+    return new Response(JSON.stringify(data), {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(
+      JSON.stringify({ error: { message: "Failed to fetch exchange rates" } }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
 };
 
 export const config = { path: "/api/exchange-rates/latest" };

--- a/functions/exchange-rates.js
+++ b/functions/exchange-rates.js
@@ -1,0 +1,12 @@
+export default async () => {
+  const url = `https://api.exchangeratesapi.io/v1/latest?access_key=${process.env.EXCHANGE_RATES_API_KEY}`;
+  const res = await fetch(url);
+  const data = await res.json();
+
+  return new Response(JSON.stringify(data), {
+    status: res.status,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const config = { path: "/api/exchange-rates/latest" };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  command = "yarn build:netlify"
+  publish = "netlify"
+
+[dev]
+  command = "yarn dev"
+  port = 3035
+  targetPort = 3030
+  framework = "vite"
+
+[functions]
+  directory = "functions"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -66,9 +66,7 @@ const fetchCurrencies = async (
   let currencyList: ICurrency[] = [];
 
   try {
-    const fetchRates = await fetch(
-      "https://api.craigmcn.com/v1/exchange-rates/latest",
-    );
+    const fetchRates = await fetch("/api/exchange-rates/latest");
     const fetchRatesJson = await fetchRates?.json();
 
     if (fetchRatesJson?.error) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -70,7 +70,9 @@ const fetchCurrencies = async (
     const fetchRatesJson = await fetchRates?.json();
 
     if (fetchRatesJson?.error) {
-      throw new Error(fetchRatesJson?.error?.message);
+      throw new Error(
+        fetchRatesJson?.error?.info ?? fetchRatesJson?.error?.message,
+      );
     }
     rates = fetchRatesJson?.rates;
     dispatch({ type: "SET_TIMESTAMP", payload: fetchRatesJson?.timestamp });


### PR DESCRIPTION
## Summary

- Replaces the `api.craigmcn.com` → CloudFront → Lambda@Edge → exchangeratesapi.io chain with a Netlify function served at `/api/exchange-rates/latest`
- Adds `functions/exchange-rates.js` (Netlify Functions v2) that proxies the exchangeratesapi.io API using `EXCHANGE_RATES_API_KEY` from the environment
- Adds `netlify.toml` to codify the build command, publish directory, functions directory, and local dev proxy config
- Updates the fetch URL in `src/utils/index.ts` to a relative path (`/api/exchange-rates/latest`) so it works at both the root and `/currency/` sub-path without hardcoding a domain
- Gitignores `deno.lock` (auto-generated by Netlify CLI scanning the function) and `.netlify/` (local CLI state)

## Prerequisites before merging

- [ ] Log into exchangeratesapi.io and regenerate the API key (old key was hardcoded in the Lambda source)
- [ ] Add `EXCHANGE_RATES_API_KEY` to Netlify site environment variables (Site configuration → Environment variables)

## Test plan

- [ ] `netlify dev` starts successfully and proxies Vite on port 3030 (Netlify CLI listens on 3035)
- [ ] `http://localhost:3035` loads the app and exchange rates fetch succeeds (check Network tab)
- [ ] `http://localhost:3035/api/exchange-rates/latest` returns JSON directly
- [ ] `yarn build:netlify` completes without error; `netlify/` output does not contain a `functions/` subdirectory
- [ ] Deploy preview on Netlify shows working currency conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)