### PR TITLE
docs: link open TODOs to GitHub Project board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,10 @@ PR #54 merged (2026-05-08). Branch `chore/sync-tooling`:
 - [x] Add `src/vite-env.d.ts` (`/// <reference types="vite/client" />`) — fixes `import.meta.env` and CSS import type errors surfaced by the Yarn bump
 - [x] Import `FormatOptionLabelMeta` from `"react-select"` root (not deep internal path) — required under `moduleResolution: "bundler"`
 
+## Open TODOs
+
+Tracked as issues in the [currency GitHub Project](https://github.com/users/craigmcn/projects/4) (GitHub Actions bump, axe tooling, Playwright E2E).
+
 ## Follow-up items — COMPLETE
 
 PR #55 merged (2026-05-08). Branch `fix/follow-ups`:


### PR DESCRIPTION
Replaces inline TODO lists in CLAUDE.md with a pointer to this repo's new GitHub Project (part of a cross-repo migration of all open TODOs from active_projects.md / CLAUDE.md files into per-repo GitHub Projects).

## Test plan
- [x] Docs-only change; no code affected
- [x] Pre-commit hook (format/lint/test) passed locally before push