### PR TITLE
fix: use canonical AlbertCSS CDN URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 
     <link
       rel="stylesheet"
-      href="https://www.craigmcn.com/albertcss/css/albert.min.css"
+      href="https://albertcss.craigmcn.com/css/albert.min.css"
     />
   </head>
 


### PR DESCRIPTION
## Summary
- Switches the AlbertCSS `<link>` in `index.html` from the legacy `www.craigmcn.com/albertcss/` URL to the canonical `albertcss.craigmcn.com` (unversioned = latest, currently v0.18.0), per the albertcss versions page.

Closes #65.

## Test plan
- [x] `yarn format:check`
- [x] `yarn build`
- [x] `yarn test:run`