### PR TITLE
chore: fix Dependabot brace-expansion alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   "resolutions": {
     "minimatch@^3.1.2": "^3.1.5",
     "minimatch@^9.0.4": "^9.0.7",
+    "brace-expansion@^1.1.7": "^1.1.16",
+    "brace-expansion@^2.0.2": "^2.1.2",
     "picomatch@^4.0.2": "^4.0.4",
     "tar": "^7.5.16",
     "glob": "^10.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,22 +1633,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+"brace-expansion@npm:^1.1.16":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+"brace-expansion@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds `resolutions` entries pinning `brace-expansion` to `^1.1.16` and `^2.1.2`, fixing GitHub Dependabot alerts #219 and #220 (DoS via exponential-time expansion of non-expanding `{}` groups).
- Both vulnerable versions were transitive, pulled in via different `minimatch` majors (3.x and 9.x).

## Test plan
- [x] `yarn install` resolves to patched versions (confirmed via `yarn why brace-expansion`)
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn tsc -b`
- [x] `yarn test:run` (44 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)