### PR TITLE
chore: pin brace-expansion v5 to patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "minimatch@^9.0.4": "^9.0.7",
     "brace-expansion@^1.1.7": "^1.1.16",
     "brace-expansion@^2.0.2": "^2.1.2",
+    "brace-expansion@^5.0.5": "^5.0.8",
     "picomatch@^4.0.2": "^4.0.4",
     "tar": "^7.5.21",
     "postcss@^8.5.16": "^8.5.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1652,12 +1652,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+"brace-expansion@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #223 (high severity): `brace-expansion@5.0.7`, pulled in transitively via `minimatch@10.2.5`, is vulnerable to a DoS via unbounded expansion length.
- Existing `resolutions` only pinned brace-expansion's v1 and v2 ranges; added a matching pin for the v5.0.5 range to the patched `5.0.8`.

## Test plan
- [x] `yarn install` — confirms `brace-expansion@5.0.8` resolved (was 5.0.7)
- [x] `yarn why brace-expansion` — all three instances (v1, v2, v5) now on patched versions
- [x] `yarn lint`, `yarn build`, `yarn test:run` — all pass
- [x] Pre-commit hook (prettier + lint + tsc + tests) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)