### PR TITLE
chore: fix Dependabot alerts #225 and #224 (brace-expansion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   "resolutions": {
     "minimatch@^3.1.2": "^3.1.5",
     "minimatch@^9.0.4": "^9.0.7",
-    "brace-expansion@^1.1.7": "^1.1.16",
-    "brace-expansion@^2.0.2": "^2.1.2",
+    "brace-expansion@^1.1.7": "^1.1.17",
+    "brace-expansion@^2.0.2": "^2.1.3",
     "brace-expansion@^5.0.5": "^5.0.8",
     "picomatch@^4.0.2": "^4.0.4",
     "tar": "^7.5.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,22 +1633,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.16":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+"brace-expansion@npm:^1.1.17":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+"brace-expansion@npm:^2.1.3":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps the `brace-expansion` yarn resolutions to close two open Dependabot alerts (both high severity, DoS via unbounded expansion length)
- Alert #225 (v1.x line): `^1.1.16` → `^1.1.17`, resolved version now 1.1.18
- Alert #224 (v2.x line): `^2.1.2` → `^2.1.3`, resolved version now 2.1.4
- Both are transitive deps pulled in via `minimatch`; existing resolutions had gone stale (previously-pinned versions fell back into the new vulnerable ranges)

## Test plan
- [x] `yarn format:check`
- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test:run` (44 tests passing)
- [x] `yarn build`
- [x] `yarn why brace-expansion` confirms all resolved copies are outside vulnerable ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)